### PR TITLE
Parse result no header

### DIFF
--- a/src/main/java/org/publichealthbioinformatics/irida/plugin/speciesabundance/SpeciesAbundancePluginUpdater.java
+++ b/src/main/java/org/publichealthbioinformatics/irida/plugin/speciesabundance/SpeciesAbundancePluginUpdater.java
@@ -144,11 +144,25 @@ public class SpeciesAbundancePluginUpdater implements AnalysisSampleUpdater {
 	Map<String, String> parseSpeciesAbundanceFile(Path speciesAbundanceFilePath) throws IOException {
 		BufferedReader speciesAbundanceReader = new BufferedReader(new FileReader(speciesAbundanceFilePath.toFile()));
 		Map<String, String> mostAbundantSpecies = new HashMap<>();
-
+		ArrayList<String> expectedHeaderFields = new ArrayList<String>(Arrays.asList(
+				"name",
+		        "taxonomy_id",
+		        "taxonomy_lvl",
+		        "kraken_assigned_reads",
+		        "added_reads",
+		        "new_est_reads",
+		        "fraction_total_reads"
+		));
 		try {
 			String headerLine = speciesAbundanceReader.readLine();
-			String mostAbundantSpeciesLine = speciesAbundanceReader.readLine();
 			ArrayList<String> headerFields = new ArrayList<String>(Arrays.asList(headerLine.split("\t")));
+			String mostAbundantSpeciesLine;
+			if (!headerFields.equals(expectedHeaderFields)) { // header not present
+					mostAbundantSpeciesLine = headerLine;
+					headerFields = expectedHeaderFields;
+			} else {
+				mostAbundantSpeciesLine = speciesAbundanceReader.readLine();
+			}
 			ArrayList<String> mostAbundantSpeciesFields = new ArrayList<String>(Arrays.asList(mostAbundantSpeciesLine.split("\t")));
 			assert headerFields.size() == mostAbundantSpeciesFields.size();
 			for (int i = 0; i < headerFields.size(); i++) {

--- a/src/test/java/org/publichealthbioinformatics/irida/plugin/speciesabundance/SpeciesAbundancePluginUpdaterTest.java
+++ b/src/test/java/org/publichealthbioinformatics/irida/plugin/speciesabundance/SpeciesAbundancePluginUpdaterTest.java
@@ -124,4 +124,14 @@ public class SpeciesAbundancePluginUpdaterTest {
         assertThat(mostAbundantSpecies, IsMapContaining.hasKey("taxonomy_id"));
         assertThat(mostAbundantSpecies, IsMapContaining.hasKey("fraction_total_reads"));
     }
+
+    @Test
+    public void testParseSpeciesAbundanceFileNoHeader() throws Throwable {
+        Path speciesAbundanceFilePath = Paths.get(ClassLoader.getSystemResource("species_abundance_no_header.tsv").toURI());
+        Map<String, String> mostAbundantSpecies = updater.parseSpeciesAbundanceFile(speciesAbundanceFilePath);
+        assertThat(mostAbundantSpecies, IsMapContaining.hasKey("name"));
+        assertThat(mostAbundantSpecies, IsMapContaining.hasKey("taxonomy_lvl"));
+        assertThat(mostAbundantSpecies, IsMapContaining.hasKey("taxonomy_id"));
+        assertThat(mostAbundantSpecies, IsMapContaining.hasKey("fraction_total_reads"));
+    }
 }

--- a/src/test/resources/species_abundance_no_header.tsv
+++ b/src/test/resources/species_abundance_no_header.tsv
@@ -1,0 +1,64 @@
+Escherichia coli	562	S	851328	1699174	2550502	0.98546
+Enterobacter hormaechei	158836	S	6381	10746	17127	0.00662
+Shigella dysenteriae	622	S	1218	3897	5115	0.00198
+Salmonella enterica	28901	S	1070	1653	2723	0.00105
+Escherichia albertii	208962	S	1927	229	2156	0.00083
+Klebsiella michiganensis	1134687	S	92	1782	1874	0.00072
+Escherichia marmotae	1499973	S	1179	103	1282	0.00050
+Shigella flexneri	623	S	330	715	1045	0.00040
+Klebsiella pneumoniae	573	S	382	247	629	0.00024
+Escherichia fergusonii	564	S	466	113	579	0.00022
+Gordonibacter massiliensis	1841863	S	550	6	556	0.00021
+Staphylococcus aureus	1280	S	405	92	497	0.00019
+Citrobacter koseri	545	S	368	32	400	0.00015
+Citrobacter amalonaticus	35703	S	60	307	367	0.00014
+Citrobacter freundii	546	S	83	216	299	0.00012
+Enterobacter cloacae	550	S	146	59	205	0.00008
+Citrobacter rodentium	67825	S	167	10	177	0.00007
+Citrobacter werkmanii	67827	S	89	31	120	0.00005
+Homo sapiens	9606	S	106	19	125	0.00005
+Shigella virus Sf6	10761	S	62	71	133	0.00005
+Cronobacter dublinensis	413497	S	97	17	114	0.00004
+Klebsiella aerogenes	548	S	104	5	109	0.00004
+Klebsiella oxytoca	571	S	79	14	93	0.00004
+Raoultella ornithinolytica	54291	S	29	81	110	0.00004
+Yersinia pestis	632	S	10	93	103	0.00004
+Cedecea neteri	158822	S	63	1	64	0.00003
+Citrobacter sp. FDAARGOS_156	1702170	S	62	23	85	0.00003
+Enterobacter asburiae	61645	S	63	15	78	0.00003
+Enterobacteriaceae bacterium ENNIH1	2066051	S	52	26	78	0.00003
+Enterobacteriaceae bacterium strain FGI 57	693444	S	84	3	87	0.00003
+Enterobacter sp. SA187	1914861	S	87	1	88	0.00003
+Klebsiella quasipneumoniae	1463165	S	45	44	89	0.00003
+Kosakonia oryzae	497725	S	27	39	66	0.00003
+Lelliottia amnigena	61646	S	72	3	75	0.00003
+Citrobacter farmeri	67824	S	43	13	56	0.00002
+[Enterobacter] lignolyticus	1334193	S	44	3	47	0.00002
+Enterobacter sp. FY-07	1692238	S	39	0	39	0.00002
+Kosakonia cowanii	208223	S	48	0	48	0.00002
+Leclercia sp. LSNIH1	1920114	S	21	31	52	0.00002
+Pluralibacter gergoviae	61647	S	46	2	48	0.00002
+Proteus mirabilis	584	S	43	4	47	0.00002
+Salmonella bongori	54736	S	56	0	56	0.00002
+Shimwellia blattae	563	S	56	0	56	0.00002
+Cronobacter condimenti	1163710	S	21	2	23	0.00001
+Cronobacter malonaticus	413503	S	12	7	19	0.00001
+Cronobacter muytjensii	413501	S	14	2	16	0.00001
+Cronobacter sakazakii	28141	S	26	12	38	0.00001
+Cronobacter turicensis	413502	S	11	2	13	0.00001
+Enterobacter cancerogenus	69218	S	37	0	37	0.00001
+Enterobacter cloacae complex sp.	2027919	S	15	2	17	0.00001
+Enterobacteria phage HK544	432201	S	12	17	29	0.00001
+Enterobacter roggenkampii	1812935	S	10	3	13	0.00001
+Enterobacter sp. 638	399742	S	23	1	24	0.00001
+Enterobacter sp. R4-368	1166130	S	32	2	34	0.00001
+Klebsiella quasivariicola	2026240	S	16	2	18	0.00001
+Klebsiella variicola	244366	S	11	7	18	0.00001
+Kluyvera intermedia	61648	S	22	4	26	0.00001
+Kosakonia sacchari	1158459	S	33	3	36	0.00001
+Lelliottia jeotgali	1907578	S	31	4	35	0.00001
+Lelliottia sp. WB101	2153385	S	29	3	32	0.00001
+Polynucleobacter necessarius	576610	S	13	0	13	0.00001
+Raoultella planticola	575	S	22	6	28	0.00001
+Serratia marcescens	615	S	11	8	19	0.00001
+Plautia stali symbiont	891974	S	11	0	11	0.00000


### PR DESCRIPTION
Handle case where output `species_abundance.tsv` file has no header.

Fixes #3 